### PR TITLE
refactor: standardize endpoints and grammar rule structure

### DIFF
--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/GrammarRuleController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/GrammarRuleController.java
@@ -1,6 +1,7 @@
 package com.fluveny.fluveny_backend.api.controller;
 
 import com.fluveny.fluveny_backend.api.ApiResponseFormat;
+import com.fluveny.fluveny_backend.api.dto.GrammarRuleRequestDTO;
 import com.fluveny.fluveny_backend.business.service.GrammarRuleService;
 import com.fluveny.fluveny_backend.infraestructure.entity.GrammarRuleEntity;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +40,10 @@ public class GrammarRuleController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponseFormat<GrammarRuleEntity>> createGrammarRule(@RequestBody GrammarRuleEntity grammarRule) {
-        GrammarRuleEntity createdRule = grammarRuleService.save(grammarRule);
+    public ResponseEntity<ApiResponseFormat<GrammarRuleEntity>> createGrammarRule(
+            @RequestBody GrammarRuleRequestDTO grammarRuleDTO) {
+
+        GrammarRuleEntity createdRule = grammarRuleService.create(grammarRuleDTO);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponseFormat<>("Grammar rule was created", createdRule));
     }
@@ -48,10 +51,9 @@ public class GrammarRuleController {
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseFormat<GrammarRuleEntity>> updateGrammarRule(
             @PathVariable String id,
-            @RequestBody GrammarRuleEntity grammarRule) {
+            @RequestBody GrammarRuleRequestDTO grammarRuleDTO) {
 
-        grammarRule.setId(id);
-        GrammarRuleEntity updatedRule = grammarRuleService.save(grammarRule);
+        GrammarRuleEntity updatedRule = grammarRuleService.update(id, grammarRuleDTO);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new ApiResponseFormat<>("Grammar rule was updated", updatedRule));
     }

--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/LevelController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/LevelController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/v1/level")
+@RequestMapping("api/v1/levels")
 public class LevelController {
 
     private LevelService levelService;

--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/ModuleController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/ModuleController.java
@@ -10,24 +10,21 @@ import com.fluveny.fluveny_backend.business.service.ModuleService;
 import com.fluveny.fluveny_backend.infraestructure.entity.ModuleEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/module")
+@RequestMapping("/api/v1/modules")
 public class ModuleController {
 
     private final ModuleService moduleService;

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/GrammarRuleRequestDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/GrammarRuleRequestDTO.java
@@ -1,0 +1,14 @@
+package com.fluveny.fluveny_backend.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GrammarRuleRequestDTO {
+    private String title;
+}

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/ModuleResponseDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/ModuleResponseDTO.java
@@ -18,5 +18,5 @@ public class ModuleResponseDTO {
     private String title;
     private String description;
     private LevelEntity level;
-    private List<GrammarRuleEntity> grammarRule;
+    private List<GrammarRuleEntity> grammarRules;
 }

--- a/src/main/java/com/fluveny/fluveny_backend/api/mapper/ModuleMapper.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/mapper/ModuleMapper.java
@@ -4,13 +4,10 @@ import com.fluveny.fluveny_backend.api.dto.ModuleRequestDTO;
 import com.fluveny.fluveny_backend.api.dto.ModuleResponseDTO;
 import com.fluveny.fluveny_backend.business.service.GrammarRuleService;
 import com.fluveny.fluveny_backend.business.service.LevelService;
-import com.fluveny.fluveny_backend.business.service.ModuleService;
-import com.fluveny.fluveny_backend.exception.BusinessException.BusinessException;
 import com.fluveny.fluveny_backend.infraestructure.entity.GrammarRuleEntity;
 import com.fluveny.fluveny_backend.infraestructure.entity.LevelEntity;
 import com.fluveny.fluveny_backend.infraestructure.entity.ModuleEntity;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -42,7 +39,7 @@ public class ModuleMapper {
             grammarRules.add(grammarRuleService.findById(grammarId));
         }
 
-        moduleEntity.setGrammarRule(grammarRules);
+        moduleEntity.setGrammarRules(grammarRules);
 
         return moduleEntity;
     }
@@ -53,10 +50,9 @@ public class ModuleMapper {
         moduleResponseDTO.setTitle(moduleEntity.getTitle());
         moduleResponseDTO.setDescription(moduleEntity.getDescription());
         moduleResponseDTO.setLevel(moduleEntity.getLevel());
-        moduleResponseDTO.setGrammarRule(moduleEntity.getGrammarRule());
+        moduleResponseDTO.setGrammarRules(moduleEntity.getGrammarRules());
         moduleResponseDTO.setId(moduleEntity.getId());
 
         return moduleResponseDTO;
     }
-
 }

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/ModuleService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/ModuleService.java
@@ -1,15 +1,11 @@
 package com.fluveny.fluveny_backend.business.service;
 
-import com.fluveny.fluveny_backend.api.ApiResponseFormat;
 import com.fluveny.fluveny_backend.exception.BusinessException.BusinessException;
 import com.fluveny.fluveny_backend.infraestructure.entity.ModuleEntity;
 import com.fluveny.fluveny_backend.infraestructure.repository.ModuleRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Optional;
@@ -69,12 +65,9 @@ public class ModuleService {
 
     }
 
-    public void validateGrammarRules(ModuleEntity moduleEntity){
-        if(moduleEntity.getGrammarRule().size() > 5){
+    private void validateGrammarRules(ModuleEntity moduleEntity) {
+        if (moduleEntity.getGrammarRules().size() > 5) {
             throw new BusinessException("A module cannot have more than 5 grammar rules", HttpStatus.BAD_REQUEST);
         }
     }
-
-
-
 }

--- a/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/GrammarRuleEntity.java
+++ b/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/GrammarRuleEntity.java
@@ -16,4 +16,5 @@ public class GrammarRuleEntity {
     @Id
     private String id;
     private String title;
+    private String slug;
 }

--- a/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/ModuleEntity.java
+++ b/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/ModuleEntity.java
@@ -20,5 +20,5 @@ public class ModuleEntity {
     private String title;
     private String description;
     private LevelEntity level;
-    private List<GrammarRuleEntity> grammarRule;
+    private List<GrammarRuleEntity> grammarRules;
 }


### PR DESCRIPTION
- Renamed API endpoints to use plural form for consistency (e.g., /grammar-rules)
- Added 'slug' attribute to GrammarRuleEntity, generated automatically from title
- Updated ModuleResponseDTO and related mappings to use 'grammarRules' instead of 'grammarRule'