### PR TITLE
refactor: standardize endpoints and grammar rule structure

### DIFF
--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/GrammarRuleController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/GrammarRuleController.java
@@ -1,8 +1,11 @@
 package com.fluveny.fluveny_backend.api.controller;
 
 import com.fluveny.fluveny_backend.api.ApiResponseFormat;
+import com.fluveny.fluveny_backend.api.dto.GrammarRuleRequestDTO;
+import com.fluveny.fluveny_backend.api.mapper.GrammarRuleMapper;
 import com.fluveny.fluveny_backend.business.service.GrammarRuleService;
 import com.fluveny.fluveny_backend.infraestructure.entity.GrammarRuleEntity;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +19,7 @@ import java.util.List;
 public class GrammarRuleController {
 
     private final GrammarRuleService grammarRuleService;
+    private final GrammarRuleMapper grammarRuleMapper;
 
     @GetMapping
     public ResponseEntity<ApiResponseFormat<List<GrammarRuleEntity>>> getAllGrammarRules() {
@@ -39,21 +43,23 @@ public class GrammarRuleController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponseFormat<GrammarRuleEntity>> createGrammarRule(@RequestBody GrammarRuleEntity grammarRule) {
-        GrammarRuleEntity createdRule = grammarRuleService.save(grammarRule);
+    public ResponseEntity<ApiResponseFormat<GrammarRuleEntity>> createGrammarRule(
+            @RequestBody GrammarRuleRequestDTO dto) {
+
+        GrammarRuleEntity entity = grammarRuleMapper.toEntity(dto);
+        GrammarRuleEntity saved = grammarRuleService.save(entity);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new ApiResponseFormat<>("Grammar rule was created", createdRule));
+                 .body(new ApiResponseFormat<>("Grammar rule was created", saved));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseFormat<GrammarRuleEntity>> updateGrammarRule(
             @PathVariable String id,
-            @RequestBody GrammarRuleEntity grammarRule) {
+            @RequestBody @Valid GrammarRuleRequestDTO dto) {
 
-        grammarRule.setId(id);
-        GrammarRuleEntity updatedRule = grammarRuleService.save(grammarRule);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new ApiResponseFormat<>("Grammar rule was updated", updatedRule));
+        GrammarRuleEntity entity = grammarRuleMapper.toEntity(dto);
+        GrammarRuleEntity updated = grammarRuleService.update(id, entity);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseFormat<>("Grammar rule was updated", updated));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/LevelController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/LevelController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/v1/level")
+@RequestMapping("api/v1/levels")
 public class LevelController {
 
     private LevelService levelService;

--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/ModuleController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/ModuleController.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/module")
+@RequestMapping("/api/v1/modules")
 public class ModuleController {
 
     private final ModuleService moduleService;

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/GrammarRuleRequestDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/GrammarRuleRequestDTO.java
@@ -1,0 +1,14 @@
+package com.fluveny.fluveny_backend.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GrammarRuleRequestDTO {
+    private String title;
+}

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/ModuleResponseDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/ModuleResponseDTO.java
@@ -18,5 +18,5 @@ public class ModuleResponseDTO {
     private String title;
     private String description;
     private LevelEntity level;
-    private List<GrammarRuleEntity> grammarRule;
+    private List<GrammarRuleEntity> grammarRules;
 }

--- a/src/main/java/com/fluveny/fluveny_backend/api/mapper/GrammarRuleMapper.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/mapper/GrammarRuleMapper.java
@@ -1,0 +1,15 @@
+package com.fluveny.fluveny_backend.api.mapper;
+
+import com.fluveny.fluveny_backend.api.dto.GrammarRuleRequestDTO;
+import com.fluveny.fluveny_backend.infraestructure.entity.GrammarRuleEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GrammarRuleMapper {
+
+    public GrammarRuleEntity toEntity(GrammarRuleRequestDTO dto) {
+        GrammarRuleEntity entity = new GrammarRuleEntity();
+        entity.setTitle(dto.getTitle());
+        return entity;
+    }
+}

--- a/src/main/java/com/fluveny/fluveny_backend/api/mapper/ModuleMapper.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/mapper/ModuleMapper.java
@@ -42,7 +42,7 @@ public class ModuleMapper {
             grammarRules.add(grammarRuleService.findById(grammarId));
         }
 
-        moduleEntity.setGrammarRule(grammarRules);
+        moduleEntity.setGrammarRules(grammarRules);
 
         return moduleEntity;
     }
@@ -53,7 +53,7 @@ public class ModuleMapper {
         moduleResponseDTO.setTitle(moduleEntity.getTitle());
         moduleResponseDTO.setDescription(moduleEntity.getDescription());
         moduleResponseDTO.setLevel(moduleEntity.getLevel());
-        moduleResponseDTO.setGrammarRule(moduleEntity.getGrammarRule());
+        moduleResponseDTO.setGrammarRules(moduleEntity.getGrammarRules());
         moduleResponseDTO.setId(moduleEntity.getId());
 
         return moduleResponseDTO;

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/GrammarRuleService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/GrammarRuleService.java
@@ -3,9 +3,11 @@ package com.fluveny.fluveny_backend.business.service;
 import com.fluveny.fluveny_backend.exception.BusinessException.BusinessException;
 import com.fluveny.fluveny_backend.infraestructure.entity.GrammarRuleEntity;
 import com.fluveny.fluveny_backend.infraestructure.repository.GrammarRuleRepository;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 import java.util.Optional;
@@ -46,14 +48,29 @@ public class GrammarRuleService {
         return rules;
     }
 
-    public GrammarRuleEntity save(GrammarRuleEntity grammarRule) {
-        Optional<GrammarRuleEntity> existingRule = grammarRuleRepository.findByTitle(grammarRule.getTitle());
+    public GrammarRuleEntity update(String id, GrammarRuleEntity updatedEntity) {
+        GrammarRuleEntity existing = grammarRuleRepository.findById(id)
+                .orElseThrow(() -> new BusinessException("Grammar rule not found: " + id, HttpStatus.NOT_FOUND));
 
-        if (existingRule.isPresent() && (grammarRule.getId() == null || !grammarRule.getId().equals(existingRule.get().getId()))) {
-            throw new BusinessException("There is already a grammar rule with that title", HttpStatus.CONFLICT);
+        grammarRuleRepository.findByTitle(updatedEntity.getTitle())
+                .filter(rule -> !rule.getTitle().equals(updatedEntity.getTitle()))
+                .ifPresent(rule -> {
+                    throw new BusinessException("Grammar rule already exists: " + rule.getTitle(), HttpStatus.CONFLICT);
+                });
+
+        existing.setTitle(updatedEntity.getTitle());
+        existing.setSlug(generateSlug(updatedEntity.getTitle()));
+
+        return grammarRuleRepository.save(existing);
+    }
+
+    public GrammarRuleEntity save(@RequestBody @Valid GrammarRuleEntity entity) {
+        Optional<GrammarRuleEntity> existing = grammarRuleRepository.findByTitle(entity.getTitle());
+        if (existing.isPresent()) {
+            throw new BusinessException("Grammar rule already exists: " + entity.getTitle(), HttpStatus.CONFLICT);
         }
-
-        return grammarRuleRepository.save(grammarRule);
+        entity.setSlug(generateSlug(entity.getTitle()));
+        return grammarRuleRepository.save(entity);
     }
 
     public void deleteById(String id) {
@@ -61,5 +78,12 @@ public class GrammarRuleService {
             throw new BusinessException("Grammar rule not found: " + id, HttpStatus.NOT_FOUND);
         }
         grammarRuleRepository.deleteById(id);
+    }
+
+    private String generateSlug(String title) {
+        if (title == null) return null;
+        return title.trim().toLowerCase()
+                .replaceAll("[^a-z0-9\\s]", "")
+                .replaceAll("\\s+", "-");
     }
 }

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/ModuleService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/ModuleService.java
@@ -70,7 +70,7 @@ public class ModuleService {
     }
 
     public void validateGrammarRules(ModuleEntity moduleEntity){
-        if(moduleEntity.getGrammarRule().size() > 5){
+        if(moduleEntity.getGrammarRules().size() > 5){
             throw new BusinessException("A module cannot have more than 5 grammar rules", HttpStatus.BAD_REQUEST);
         }
     }

--- a/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/GrammarRuleEntity.java
+++ b/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/GrammarRuleEntity.java
@@ -16,4 +16,5 @@ public class GrammarRuleEntity {
     @Id
     private String id;
     private String title;
+    private String slug;
 }

--- a/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/ModuleEntity.java
+++ b/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/ModuleEntity.java
@@ -20,5 +20,5 @@ public class ModuleEntity {
     private String title;
     private String description;
     private LevelEntity level;
-    private List<GrammarRuleEntity> grammarRule;
+    private List<GrammarRuleEntity> grammarRules;
 }


### PR DESCRIPTION
- Renamed API endpoints to use plural form for consistency (e.g., /grammar-rules)
- Added 'slug' attribute to GrammarRuleEntity, generated automatically from title
- Updated ModuleResponseDTO and related mappings to use 'grammarRules' instead of 'grammarRule'