### PR TITLE
Enhance Authentication Flow, DTOs, and User Data Retrieval

### DIFF
--- a/src/main/java/com/fluveny/fluveny_backend/RunOnStartup.java
+++ b/src/main/java/com/fluveny/fluveny_backend/RunOnStartup.java
@@ -3,6 +3,7 @@ package com.fluveny.fluveny_backend;
 import com.fluveny.fluveny_backend.api.dto.UserRequestDTO;
 import com.fluveny.fluveny_backend.api.mapper.UserMapper;
 import com.fluveny.fluveny_backend.business.service.UserService;
+import com.fluveny.fluveny_backend.exception.BusinessException.BusinessException;
 import com.fluveny.fluveny_backend.infraestructure.entity.GrammarRuleEntity;
 import com.fluveny.fluveny_backend.infraestructure.entity.LevelEntity;
 import com.fluveny.fluveny_backend.infraestructure.entity.RoleEntity;
@@ -15,13 +16,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
-import javax.management.relation.Role;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Level;
 
 @Component
-public class RunOnStatup implements CommandLineRunner {
+public class RunOnStartup implements CommandLineRunner {
 
     @Autowired
     private LevelRepository levelRepository;
@@ -48,9 +47,10 @@ public class RunOnStatup implements CommandLineRunner {
             roleRepository.saveAll(roles);
         }
 
-        if(userService.getUserByEmail("test@fluveny-br.com") == null){
+        try {
+            userService.getUserByEmail("test@fluveny-br.com");
+        } catch (BusinessException e) {
             UserRequestDTO userRequestDTO = new UserRequestDTO();
-
             userRequestDTO.setUsername("content_creator_tester");
             userRequestDTO.setPassword("testPassword1234_");
             userRequestDTO.setEmail("test@fluveny-br.com");
@@ -58,9 +58,7 @@ public class RunOnStatup implements CommandLineRunner {
             UserEntity user = userMapper.toEntity(userRequestDTO);
             Optional<RoleEntity> role = roleRepository.findByName("CONTENT_CREATOR");
 
-            if(role.isPresent()){
-                user.setRole(role.get());
-            }
+            role.ifPresent(user::setRole);
 
             userService.createUser(user);
         }

--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/AuthController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/AuthController.java
@@ -60,7 +60,7 @@ public class AuthController {
                                 .secure(false)
                                 .path("/")
                                 .maxAge(24 * 60 * 60)
-                                .sameSite("None")
+                                .sameSite("Lax")
                                 .build();
 
         LoginResponseDTO responseBody = LoginResponseDTO.from(serviceResult);

--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/AuthController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/AuthController.java
@@ -1,17 +1,17 @@
 package com.fluveny.fluveny_backend.api.controller;
 
 import com.fluveny.fluveny_backend.api.ApiResponseFormat;
-import com.fluveny.fluveny_backend.api.dto.*;
+import com.fluveny.fluveny_backend.api.dto.LoginRequestDTO;
+import com.fluveny.fluveny_backend.api.dto.LoginResponseDTO;
+import com.fluveny.fluveny_backend.api.dto.LoginResultDTO;
 import com.fluveny.fluveny_backend.business.service.AuthorizationService;
 import com.fluveny.fluveny_backend.exception.BusinessException.BusinessException;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +19,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -50,295 +53,63 @@ public class AuthController {
             @Valid @RequestBody LoginRequestDTO loginRequest,
             HttpServletRequest request) {
 
-        try {
+        LoginResultDTO serviceResult = authorizationService.login(loginRequest, request);
 
-            String ipAddress = getClientIpAddress(request);
-            boolean requiresCaptcha = authorizationService.requiresCaptcha(loginRequest.getUsername(), ipAddress);
+        ResponseCookie cookie = ResponseCookie.from("fluveny-token", serviceResult.getToken())
+                                .httpOnly(true)
+                                .secure(false)
+                                .path("/")
+                                .maxAge(24 * 60 * 60)
+                                .sameSite("None")
+                                .build();
 
-            if (requiresCaptcha) {
-                throw new BusinessException(
-                        "CAPTCHA verification required due to multiple failed login attempts. Please complete CAPTCHA and try again.",
-                        HttpStatus.TOO_MANY_REQUESTS
-                );
-            }
+        LoginResponseDTO responseBody = LoginResponseDTO.from(serviceResult);
 
-            LoginResponseDTO response = authorizationService.login(loginRequest, request);
-
-            ResponseCookie cookie = ResponseCookie.from("fluveny-token", response.getToken())
-                                    .httpOnly(true)
-                                    .secure(true)
-                                    .path("/")
-                                    .maxAge(24 * 60 * 60)
-                                    .sameSite("None")
-                                    .build();
-
-            return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(new ApiResponseFormat<>("Login successful", response));
-
-        } catch (BusinessException e) {
-            throw e;
-        }
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(new ApiResponseFormat<>("Login successful", responseBody));
     }
 
-    /**
-     * Authenticates user with CAPTCHA verification.
-     * Required when user has multiple failed login attempts.
-     *
-     * @param captchaRequest User credentials with CAPTCHA response
-     * @param request HTTP request for IP extraction
-     * @return JWT token and user information on success
-     */
-    @Operation(summary = "User login with CAPTCHA", description = "Authenticates user with CAPTCHA verification")
+    @Operation(summary = "Get current user info", description = "Validates the token from the HttpOnly cookie and returns the current user's data.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Login successful",
-                    content = @Content(schema = @Schema(implementation = LoginResponseDTO.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid input or CAPTCHA verification failed"),
-            @ApiResponse(responseCode = "401", description = "Invalid credentials"),
-            @ApiResponse(responseCode = "423", description = "Account locked")
+            @ApiResponse(responseCode = "200", description = "User data retrieved successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - no valid session cookie found")
     })
-    @PostMapping("/login/captcha")
-    public ResponseEntity<ApiResponseFormat<LoginResponseDTO>> loginWithCaptcha(
-            @Valid @RequestBody CaptchaRequestDTO captchaRequest,
-            HttpServletRequest request) {
-
-        try {
-            // TODO: Implement CAPTCHA validation here
-
-            if (captchaRequest.getCaptchaResponse() == null || captchaRequest.getCaptchaResponse().trim().isEmpty()) {
-                throw new BusinessException("Invalid CAPTCHA response", HttpStatus.BAD_REQUEST);
-            }
-
-            LoginRequestDTO loginRequest = new LoginRequestDTO();
-            loginRequest.setUsername(captchaRequest.getUsername());
-            loginRequest.setPassword(captchaRequest.getPassword());
-
-            LoginResponseDTO response = authorizationService.login(loginRequest, request);
-            return ResponseEntity.ok(new ApiResponseFormat<>("Login successful with CAPTCHA verification", response));
-
-        } catch (BusinessException e) {
-            throw e;
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponseFormat<LoginResponseDTO>> getMyProfile(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new BusinessException("No valid session found", HttpStatus.UNAUTHORIZED);
         }
+
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        String email = authorizationService.findEmailByUsername(userDetails.getUsername());
+
+        String role = userDetails.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .map(r -> r.replace("ROLE_", ""))
+                .orElse("USER");
+
+        LoginResponseDTO response = new LoginResponseDTO(userDetails.getUsername(), email, role);
+
+        return ResponseEntity.ok(new ApiResponseFormat<>("User authenticated", response));
     }
 
-    /**
-     * Standard logout endpoint using token in request body.
-     *
-     * @param logoutRequest Request containing JWT token to invalidate
-     * @param request HTTP request for IP extraction
-     * @return Logout confirmation message
-     */
-    @Operation(
-            summary = "User logout",
-            description = "Standard logout endpoint. Invalidates JWT token sent in request body."
-    )
+    @Operation(summary = "User logout", description = "Clears the HttpOnly session cookie.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Logout successful"),
-            @ApiResponse(responseCode = "400", description = "Invalid input or missing token"),
-            @ApiResponse(responseCode = "401", description = "Invalid or expired token")
+            @ApiResponse(responseCode = "200", description = "Logout successful")
     })
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponseFormat<String>> logout(
-            @Valid @RequestBody LogoutRequestDTO logoutRequest,
-            HttpServletRequest request) {
+    public ResponseEntity<ApiResponseFormat<String>> logout() {
+        ResponseCookie cookie = ResponseCookie.from("fluveny-token", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .build();
 
-        try {
-
-            if (logoutRequest.getToken() == null || logoutRequest.getToken().trim().isEmpty()) {
-                throw new BusinessException("Token is required", HttpStatus.BAD_REQUEST);
-            }
-
-            String message = authorizationService.logout(logoutRequest.getToken(), request);
-            ResponseCookie cookie = ResponseCookie.from("fluveny-token", "")
-                    .httpOnly(false)
-                    .secure(true)
-                    .path("/")
-                    .maxAge(0)
-                    .build();
-            return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(new ApiResponseFormat<>(message, null));
-
-        } catch (BusinessException e) {
-            throw e;
-        }
-    }
-
-    /**
-     * Alternative logout endpoint using Authorization header.
-     * More RESTful approach where token is sent in Authorization header instead of request body.
-     *
-     * @param authorizationHeader Bearer token in Authorization header
-     * @param request HTTP request for IP extraction
-     * @return Logout confirmation message
-     */
-    @Operation(
-            summary = "User logout (Authorization header)",
-            description = "Alternative logout endpoint using Authorization header. Client must remove JWT token from storage."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Logout successful"),
-            @ApiResponse(responseCode = "400", description = "Invalid or missing Authorization header"),
-            @ApiResponse(responseCode = "401", description = "Invalid or expired token")
-    })
-    @PostMapping("/logout-header")
-    public ResponseEntity<ApiResponseFormat<String>> logoutWithHeader(
-            @Parameter(description = "Bearer token in Authorization header")
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-            HttpServletRequest request) {
-
-        try {
-            if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-                throw new BusinessException("Authorization header with Bearer token is required", HttpStatus.BAD_REQUEST);
-            }
-
-            String token = authorizationHeader.substring(7);
-            String message = authorizationService.logout(token, request);
-            return ResponseEntity.ok(new ApiResponseFormat<>(message, null));
-
-        } catch (BusinessException e) {
-            throw e;
-        }
-    }
-
-    /**
-     * Checks if CAPTCHA is required for a specific username and IP.
-     * Used by frontend to determine if CAPTCHA should be displayed.
-     *
-     * @param username Username to check
-     * @param request HTTP request for IP extraction
-     * @return CAPTCHA requirement status
-     */
-    @Operation(summary = "Check CAPTCHA requirement", description = "Determines if CAPTCHA is required for login attempt")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "CAPTCHA requirement status returned",
-                    content = @Content(schema = @Schema(implementation = CaptchaCheckResponseDTO.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid username")
-    })
-    @GetMapping("/captcha/check")
-    public ResponseEntity<ApiResponseFormat<CaptchaCheckResponseDTO>> checkCaptchaRequirement(
-            @Parameter(description = "Username to check CAPTCHA requirement for")
-            @RequestParam String username,
-            HttpServletRequest request) {
-
-        try {
-            if (username == null || username.trim().isEmpty()) {
-                throw new BusinessException("Username is required", HttpStatus.BAD_REQUEST);
-            }
-
-            String ipAddress = getClientIpAddress(request);
-            boolean requiresCaptcha = authorizationService.requiresCaptcha(username, ipAddress);
-
-            CaptchaCheckResponseDTO response = new CaptchaCheckResponseDTO();
-            response.setRequiresCaptcha(requiresCaptcha);
-            response.setAccountLocked(false);
-            response.setMessage(requiresCaptcha ?
-                    "CAPTCHA verification required due to previous failed attempts" :
-                    "No CAPTCHA required");
-            response.setFailedAttempts(0);
-
-            return ResponseEntity.ok(new ApiResponseFormat<>("CAPTCHA requirement checked", response));
-
-        } catch (BusinessException e) {
-            throw e;
-        }
-    }
-
-    /**
-     * Initiates password recovery process.
-     *
-     * NOTE: This endpoint is not yet implemented. Email service integration is required.
-     *
-     * @param recoveryRequest Username or email for password recovery
-     * @return Not implemented response
-     */
-    @Operation(
-            summary = "Initiate password recovery",
-            description = "Password recovery feature is not yet implemented. Requires email service integration for sending recovery instructions."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "501", description = "Password recovery feature not implemented yet"),
-            @ApiResponse(responseCode = "400", description = "Invalid input")
-    })
-    @PostMapping("/password/recovery")
-    public ResponseEntity<ApiResponseFormat<String>> initiatePasswordRecovery(
-            @Valid @RequestBody PasswordRecoveryRequestDTO recoveryRequest) {
-
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-                .body(new ApiResponseFormat<>(
-                        "Password recovery feature is not yet implemented. This will be available in a future release.",
-                        null
-                ));
-    }
-
-    /**
-     * Validates a JWT token.
-     * Used for token verification in other services or frontend.
-     *
-     * @param token JWT token to validate
-     * @return Token validation result
-     */
-    @Operation(summary = "Validate JWT token", description = "Validates if a JWT token is still valid")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Token validation result"),
-            @ApiResponse(responseCode = "400", description = "Token is required")
-    })
-    @PostMapping("/token/validate")
-    public ResponseEntity<ApiResponseFormat<Boolean>> validateToken(
-            @Parameter(description = "JWT token to validate")
-            @RequestParam String token) {
-
-        try {
-            if (token == null || token.trim().isEmpty()) {
-                throw new BusinessException("Token is required", HttpStatus.BAD_REQUEST);
-            }
-
-            boolean isValid = authorizationService.validateToken(token);
-            String message = isValid ? "Token is valid" : "Token is invalid or expired";
-
-            return ResponseEntity.ok(new ApiResponseFormat<>(message, isValid));
-
-        } catch (BusinessException e) {
-            throw e;
-        }
-    }
-
-    /**
-     * Extracts username from JWT token.
-     *
-     * @param token JWT token
-     * @return Username extracted from token
-     */
-    @Operation(summary = "Extract username from token", description = "Gets username from a valid JWT token")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Username extracted successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid token")
-    })
-    @PostMapping("/token/username")
-    public ResponseEntity<ApiResponseFormat<String>> getUsernameFromToken(
-            @Parameter(description = "JWT token")
-            @RequestParam String token) {
-
-        try {
-            if (token == null || token.trim().isEmpty()) {
-                throw new BusinessException("Token is required", HttpStatus.BAD_REQUEST);
-            }
-
-            String username = authorizationService.getUsernameFromToken(token);
-            return ResponseEntity.ok(new ApiResponseFormat<>("Username extracted successfully", username));
-
-        } catch (Exception e) {
-            throw new BusinessException("Invalid token", HttpStatus.BAD_REQUEST);
-        }
-    }
-
-    private String getClientIpAddress(HttpServletRequest request) {
-        String xForwardedFor = request.getHeader("X-Forwarded-For");
-        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
-            return xForwardedFor.split(",")[0].trim();
-        }
-
-        String xRealIp = request.getHeader("X-Real-IP");
-        if (xRealIp != null && !xRealIp.isEmpty()) {
-            return xRealIp;
-        }
-
-        return request.getRemoteAddr();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(new ApiResponseFormat<>("Logout successful", null));
     }
 }

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/LoginRequestDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/LoginRequestDTO.java
@@ -1,5 +1,6 @@
 package com.fluveny.fluveny_backend.api.dto;
 
+import com.fluveny.fluveny_backend.validation.UsernameOrEmail;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -19,11 +20,8 @@ public class LoginRequestDTO {
     @NotBlank(message = "Username cannot be blank")
     @Size(min = 8, max = 200,
             message = "Username must be between 8 and 200 characters")
-    @Pattern(
-            regexp = "^[a-zA-Z0-9._]+$",
-            message = "Username can only contain letters, numbers, dots, and underscores"
-    )
-    private String username;
+    @UsernameOrEmail
+    private String usernameOrEmail;
 
     @NotNull(message = "Password is required")
     @NotBlank(message = "Password cannot be blank")

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/LoginResponseDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/LoginResponseDTO.java
@@ -1,5 +1,6 @@
 package com.fluveny.fluveny_backend.api.dto;
 
+import jdk.jfr.TransitionFrom;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +11,23 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginResponseDTO {
-    private String token;
     private String username;
     private String email;
     private String role;
-    private String message;
+
+    /**
+     * Creates a LoginResponseDTO from a LoginResultDTO.
+     * This is a factory method used for mapping the internal service DTO
+     * to the external API response DTO, omitting sensitive data like the token.
+     *
+     * @param result The internal DTO returned by the service layer.
+     * @return A new LoginResponseDTO instance ready for the API response.
+     */
+    public static LoginResponseDTO from(LoginResultDTO result) {
+        return new LoginResponseDTO(
+                result.getUsername(),
+                result.getEmail(),
+                result.getRole()
+        );
+    }
 }

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/LoginResultDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/LoginResultDTO.java
@@ -1,0 +1,18 @@
+package com.fluveny.fluveny_backend.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResultDTO {
+    private String username;
+    private String email;
+    private String role;
+    private String token;
+}
+

--- a/src/main/java/com/fluveny/fluveny_backend/config/security/JwtUtil.java
+++ b/src/main/java/com/fluveny/fluveny_backend/config/security/JwtUtil.java
@@ -25,7 +25,7 @@ public class JwtUtil {
 
     public String generateToken(UserEntity user) {
         Instant now = Instant.now();
-        Instant expiration = now.plus(2, ChronoUnit.HOURS); // Token expires in 2 hours
+        Instant expiration = now.plus(24, ChronoUnit.HOURS);
 
         return JWT.create()
                 .withSubject(user.getUsername())

--- a/src/main/java/com/fluveny/fluveny_backend/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/fluveny/fluveny_backend/config/security/SecurityConfiguration.java
@@ -36,6 +36,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/captcha/check").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/token/validate").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/token/username").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/me").permitAll()
 
                         // Grammar Rule Controller
                         .requestMatchers(HttpMethod.GET, "/api/v1/grammar-rules").permitAll()

--- a/src/main/java/com/fluveny/fluveny_backend/validation/UsernameOrEmail.java
+++ b/src/main/java/com/fluveny/fluveny_backend/validation/UsernameOrEmail.java
@@ -1,0 +1,15 @@
+package com.fluveny.fluveny_backend.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UsernameOrEmailValidator.class)
+@Documented
+public @interface UsernameOrEmail {
+    String message() default "Formato de nome de usuário ou e-mail inválido";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/fluveny/fluveny_backend/validation/UsernameOrEmailValidator.java
+++ b/src/main/java/com/fluveny/fluveny_backend/validation/UsernameOrEmailValidator.java
@@ -1,0 +1,25 @@
+package com.fluveny.fluveny_backend.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class UsernameOrEmailValidator implements ConstraintValidator<UsernameOrEmail, String> {
+
+    private static final Pattern USERNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+
+        if (value.contains("@")) {
+            return EMAIL_PATTERN.matcher(value).matches();
+        } else {
+            return USERNAME_PATTERN.matcher(value).matches();
+        }
+    }
+}


### PR DESCRIPTION
#### **1. Enhanced `/login` Endpoint with Unified Credentials**
The `/login` endpoint has updated, it now accepts either a **username** or an **email** as the login identifier.

* **Service Layer:** The `AuthorizationService` was modified to correctly identify and retrieve the user entity whether a username or an email is provided.
* **Validation:** A new custom validation annotation was used in the `LoginRequestDTO`. This ensures that the input string is validated against either a valid email pattern or a valid username pattern.

#### **2. DTO Refactoring**
To better separate internal data from the API response, the DTOs for the login process have been refactored:

* **New `LoginResultDTO`:** This new internal DTO is now returned by the `AuthorizationService`. It contains the complete set of data generated upon successful authentication, including the JWT token.
* **Modified `LoginResponseDTO`:** The existing `LoginResponseDTO`, which is exposed in the API response body, has been updated. It now exclusively contains non-sensitive user information (e.g., username, email, and role) and no longer includes the token.

#### **3. New `/me` Endpoint for User Session Retrieval**

* **Purpose:** This endpoint allows the frontend to retrieve the current user's data (username, email, role) by leveraging the `HttpOnly` token cookie sent with the request.
* **Use Case:** It is particularly useful for scenarios where the frontend state is lost (e.g., after a page refresh) and user information needs to be securely re-fetched to re-establish the application's state without storing sensitive data in `localStorage`.

#### **4. Refactoring of `CONTENT_CREATOR` Seeding Logic**
The initial data seeding process has been refined for better clarity and maintainability.

* **File Renaming:** The startup file responsible for seeding initial data has been renamed to more accurately reflect its purpose.
* **Logic Update:** The logic for creating the initial user with the `CONTENT_CREATOR` role has been fixed.