### PR TITLE
Feature/delete exercise endpoint us 1916

### DIFF
--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/FinalChallengeExerciseController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/FinalChallengeExerciseController.java
@@ -123,4 +123,40 @@ public class FinalChallengeExerciseController {
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseFormat<ExerciseResponseDTO>("Exercise updated with successfully", exerciseMapper.toDTO(exercise)));
     }
 
+    @Operation(summary = "Delete an Exercise from Final Challenge",
+            description = "This endpoint is used to delete an exercise from final challenge")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Exercise deleted successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseFormat.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Bad request for application",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseFormat.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Exercise not found",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseFormat.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Server error",
+                    content  = @Content(
+                            mediaType = "application/json",
+                            schema =  @Schema(implementation = ApiResponseFormat.class)
+                    )
+            )
+    })
+    @DeleteMapping("/{id_exercise}")
+    public ResponseEntity<ApiResponseFormat<Void>> deleteExercise(
+            @PathVariable String id_module,
+            @PathVariable String id_exercise){
+        exerciseFinalChallengeService.deleteExerciseAndValidateFinalChallenge(id_exercise, id_module);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ApiResponseFormat<>("Exercise deleted successfully", null));
+    }
 }

--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/GrammarRuleExerciseController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/GrammarRuleExerciseController.java
@@ -141,4 +141,42 @@ public class GrammarRuleExerciseController {
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseFormat<ExerciseResponseDTO>("Exercise updated with successfully", exerciseMapper.toDTO(exercise)));
     }
 
+    @Operation(summary = "Delete an Exercise",
+            description = "This endpoint is used to delete an exercise")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Exercise deleted successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseFormat.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Bad request for application",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseFormat.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Exercise not found",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseFormat.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Server error",
+                    content  = @Content(
+                            mediaType = "application/json",
+                            schema =  @Schema(implementation = ApiResponseFormat.class)
+                    )
+            )
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponseFormat<Void>> deleteExercise(
+            @PathVariable String id_grammarRuleModule,
+            @PathVariable String id_module,
+            @PathVariable String id){
+        moduleService.grammarRuleModuleExistsInModule(id_module, id_grammarRuleModule);
+        exerciseService.deleteExerciseAndValidateGrammarRuleModule(id, id_grammarRuleModule);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ApiResponseFormat<>("Exercise deleted successfully", null));
+    }
 }

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/ExerciseFinalChallengeService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/ExerciseFinalChallengeService.java
@@ -51,4 +51,17 @@ public class ExerciseFinalChallengeService {
         return savedExercise;
     }
 
+    public void deleteExerciseAndValidateFinalChallenge(String id, String idModule) {
+
+        Optional<ExerciseEntity> exerciseEntity = exerciseRepository.findById(id);
+
+        if(exerciseEntity.isEmpty()) {
+            throw new BusinessException("No Exercise with this ID was found.", HttpStatus.NOT_FOUND);
+        }
+
+        moduleService.exerciseExistInFinalChallenge(id, idModule);
+
+        exerciseRepository.deleteById(id);
+    }
+
 }

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/ExerciseService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/ExerciseService.java
@@ -74,4 +74,17 @@ public class ExerciseService {
         saveContentManager.addExerciseToGrammarRuleModule(exerciseEntity.getGrammarRuleModuleId(), savedExercise);
         return savedExercise;
     }
+
+    public void deleteExerciseAndValidateGrammarRuleModule(String id, String idGrammarRuleModule) {
+
+        Optional<ExerciseEntity> exerciseEntity = exerciseRepository.findById(id);
+
+        if(exerciseEntity.isEmpty()) {
+            throw new BusinessException("No Exercise with this ID was found.", HttpStatus.NOT_FOUND);
+        }
+
+        saveContentManager.exerciseExistInGrammarRuleModule(id, idGrammarRuleModule);
+
+        exerciseRepository.deleteById(id);
+    }
 }


### PR DESCRIPTION
## Summary
Implements exercise deletion endpoints for content creators to remove exercises from grammar rule modules and final challenges.

## Changes
- Added DELETE endpoints in `GrammarRuleExerciseController` and `FinalChallengeExerciseController`
- Implemented deletion methods in `ExerciseService` and `ExerciseFinalChallengeService`
- Added validation for exercise and module existence before deletion
- Included Swagger documentation

## Endpoints
- `DELETE /api/v1/modules/{id_module}/grammar-rule-modules/{id_grammarRuleModule}/exercises/{id}`
- `DELETE /api/v1/modules/{id_module}/final-challenge/{id_exercise}`