### PR TITLE
fix: use MongoTemplate with ObjectId conversion for module search fil…

### DIFF
--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/ModuleController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/ModuleController.java
@@ -95,7 +95,10 @@ public class ModuleController implements IntroductionController, ModuleInterface
             @RequestParam Integer pageSize,
             Authentication authentication
     ){
-        System.out.println();
+        System.out.println("moduleName: " + moduleName);
+        System.out.println("grammarRulesId: " + grammarRulesId);
+        System.out.println("levelsId: " + levelsId);
+        System.out.println("status: " + status);
 
         if (authentication == null || !authentication.isAuthenticated()) {
             throw new BusinessException("No valid session found", HttpStatus.UNAUTHORIZED);

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/SearchStudentService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/SearchStudentService.java
@@ -16,6 +16,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -39,8 +42,27 @@ public class SearchStudentService {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
 
-        var queryResult = moduleRepository.searchByModuleNameLevelOrGrammarRules(searchModuleStudentDTO.getModuleName(),searchModuleStudentDTO.getLevelId(),searchModuleStudentDTO.getGrammarRulesId(),pageable);
-        List<ModuleEntity> moduleEntities = queryResult.getContent();
+        Query query = new Query();
+        List<Criteria> criteriaList = new ArrayList<>();
+                if (searchModuleStudentDTO.getModuleName() != null && !searchModuleStudentDTO.getModuleName().isEmpty()) {
+                criteriaList.add(Criteria.where("title").regex(".*" + searchModuleStudentDTO.getModuleName() + ".*", "i"));
+            }
+        if (searchModuleStudentDTO.getLevelId() != null && !searchModuleStudentDTO.getLevelId().isEmpty()) {
+                List<ObjectId> levelObjectIds = searchModuleStudentDTO.getLevelId().stream().map(ObjectId::new).toList();
+                criteriaList.add(Criteria.where("level._id").in(levelObjectIds));
+            }
+        if (searchModuleStudentDTO.getGrammarRulesId() != null && !searchModuleStudentDTO.getGrammarRulesId().isEmpty()) {
+                List<ObjectId> grammarObjectIds = searchModuleStudentDTO.getGrammarRulesId().stream().map(ObjectId::new).toList();
+                criteriaList.add(Criteria.where("grammarRules._id").in(grammarObjectIds));
+            }
+        if (!criteriaList.isEmpty()) {
+                query.addCriteria(new Criteria().andOperator(criteriaList.toArray(new Criteria[0])));
+            }
+                long total = mongoTemplate.count(query, ModuleEntity.class);
+        query.with(pageable);
+        List<ModuleEntity> moduleEntities = mongoTemplate.find(query, ModuleEntity.class);
+
+
         // Transforming modules into DTOS
         List<ModuleResponseStudentDTO> moduleResponseStudentDTOList = new ArrayList<>();
         for (ModuleEntity moduleEntity : moduleEntities) {
@@ -67,7 +89,7 @@ public class SearchStudentService {
             }
         }
 
-        return new PageImpl<>(moduleResponseStudentDTOList, pageable, queryResult.getTotalElements());
+        return new PageImpl<>(moduleResponseStudentDTOList, pageable, total);
 
     }
 

--- a/src/main/java/com/fluveny/fluveny_backend/infraestructure/repository/ModuleRepository.java
+++ b/src/main/java/com/fluveny/fluveny_backend/infraestructure/repository/ModuleRepository.java
@@ -13,8 +13,8 @@ public interface ModuleRepository extends MongoRepository<ModuleEntity, String> 
     Optional<ModuleEntity> findByTitle(String title);
     @Query("{ " +
             "'title':          ?#{ [0] == null || [0].isEmpty() ? { $exists: true } : { $regex: '.*' + [0] + '.*', $options: 'i' } }, " +
-            "'level.id':       ?#{ [1] == null || [1].isEmpty() ? { $exists: true } : { $in: [1] } }, " +
-            "'grammarRules.id':?#{ [2] == null || [2].isEmpty() ? { $exists: true } : { $all: [2] } } " +
+            "'level._id':       ?#{ [1] == null || [1].isEmpty() ? { $exists: true } : { $in: [1] } }, " +
+            "'grammarRules._id':?#{ [2] == null || [2].isEmpty() ? { $exists: true } : { $in: [2] } } " +
             "}")
     Page<ModuleEntity> searchByModuleNameLevelOrGrammarRules(String moduleName, List<String> levelIds, List<String> grammarRulesIds, Pageable pageable);
 }


### PR DESCRIPTION
fix: resolve student module search filters not returning results
Filters by grammar rule and level were silently ignored because the repository query compared filter values as plain strings against fields stored as ObjectId in MongoDB, resulting in no matches.
Replaced the SPEL-based @Query in ModuleRepository with a programmatic MongoTemplate query using Criteria, which correctly converts string IDs to ObjectId before comparison.
Root cause: Type mismatch between query parameters (String) and MongoDB storage format (ObjectId).
Impact: Grammar rule and level filters now return correct results.