### PR TITLE
Feat/first access validation

### DIFF
--- a/src/main/java/com/fluveny/fluveny_backend/api/controller/AuthController.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/controller/AuthController.java
@@ -104,7 +104,8 @@ public class AuthController {
                 userEntity.getXp(),
                 userEntity.getMaxXp(),
                 userEntity.getSoundEnabled(),
-                userEntity.getRequiresPasswordReset()
+                userEntity.getRequiresPasswordReset(),
+                userEntity.getRequiresProfileSetup()
         );
 
         return ResponseEntity.ok(new ApiResponseFormat<>("User authenticated", response));

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/LoginRequestDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/LoginRequestDTO.java
@@ -28,7 +28,7 @@ public class LoginRequestDTO {
     @Size(min = 8, max = 200,
             message = "Password must be between 8 and 200 characters")
     @Pattern(
-            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&_\\-])[A-Za-z\\d@$!%*?&_\\-]+$",
+            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&_.\\-])[A-Za-z\\d@$!%*?&_.\\-]+$",
             message = "Password must contain at least one uppercase letter, one number, and one special character"
     )
     private String password;

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/LoginResponseDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/LoginResponseDTO.java
@@ -21,6 +21,7 @@ public class LoginResponseDTO {
     private Long maxXp;
     private Boolean soundEnabled;
     private Boolean requiresPasswordReset;
+    private Boolean requiresProfileSetup;
 
     /**
      * Creates a LoginResponseDTO from a LoginResultDTO.
@@ -42,7 +43,8 @@ public class LoginResponseDTO {
                 result.getXp(),
                 result.getMaxXp(),
                 result.getSoundEnabled(),
-                result.getRequiresPasswordReset()
+                result.getRequiresPasswordReset(),
+                result.getRequiresProfileSetup()
         );
     }
 }

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/LoginResultDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/LoginResultDTO.java
@@ -21,6 +21,7 @@ public class LoginResultDTO {
     private Long maxXp;
     private Boolean soundEnabled;
     private Boolean requiresPasswordReset;
+    private Boolean requiresProfileSetup;
     private String token;
 }
 

--- a/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/UserResponseDTO.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/dto/auth/UserResponseDTO.java
@@ -21,4 +21,5 @@ public class UserResponseDTO {
     private Long maxXp;
     private Boolean soundEnabled;
     private Boolean requiresPasswordReset;
+    private Boolean requiresProfileSetup;
 }

--- a/src/main/java/com/fluveny/fluveny_backend/api/mapper/UserMapper.java
+++ b/src/main/java/com/fluveny/fluveny_backend/api/mapper/UserMapper.java
@@ -45,6 +45,7 @@ public class UserMapper {
         userDTO.setMaxXp(userEntity.getMaxXp());
         userDTO.setSoundEnabled(userEntity.getSoundEnabled());
         userDTO.setRequiresPasswordReset(userEntity.getRequiresPasswordReset());
+        userDTO.setRequiresProfileSetup(userEntity.getRequiresProfileSetup());
         return userDTO;
     }
 }

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/AdminService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/AdminService.java
@@ -69,6 +69,7 @@ public class AdminService {
         userEntity.setRole(role);
         
         userEntity.setRequiresPasswordReset(true);
+        userEntity.setRequiresProfileSetup(true);
 
         userRepository.save(userEntity);
 
@@ -84,7 +85,7 @@ public class AdminService {
         String upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         String lower = "abcdefghijklmnopqrstuvwxyz";
         String digits = "0123456789";
-        String specials = "!@#$%";
+        String specials = "@$!%*?&_-";
         String allChars = upper + lower + digits + specials;
 
         StringBuilder password = new StringBuilder();

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/AuthorizationService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/AuthorizationService.java
@@ -100,6 +100,7 @@ public class AuthorizationService {
                 user.getMaxXp(), 
                 user.getSoundEnabled(), 
                 user.getRequiresPasswordReset(),
+                user.getRequiresProfileSetup(),
                 token
         );
     }

--- a/src/main/java/com/fluveny/fluveny_backend/business/service/UserService.java
+++ b/src/main/java/com/fluveny/fluveny_backend/business/service/UserService.java
@@ -70,6 +70,7 @@ public class UserService {
         user.setName(dto.getName());
         user.setAvatar(dto.getAvatar());
         user.setBackground(dto.getBackground());
+        user.setRequiresProfileSetup(false);
 
         return userRepository.save(user);
     }

--- a/src/main/java/com/fluveny/fluveny_backend/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/fluveny/fluveny_backend/config/security/SecurityConfiguration.java
@@ -100,6 +100,9 @@ public class SecurityConfiguration {
                                 "/swagger-ui.html"
                         ).permitAll()
 
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/password").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/profile").authenticated()
+
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/fluveny/fluveny_backend/config/security/SecurityFilter.java
+++ b/src/main/java/com/fluveny/fluveny_backend/config/security/SecurityFilter.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import com.fluveny.fluveny_backend.infraestructure.entity.auth.UserEntity;
 
 import java.io.IOException;
 
@@ -24,19 +25,67 @@ public class SecurityFilter extends OncePerRequestFilter {
     UserService userService;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)  throws ServletException, IOException {
-        var token = this.recoveryToken(request);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
 
-        if("OPTIONS".equalsIgnoreCase(request.getMethod())){
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        if(token != null && jwtUtil.validateToken(token)){
-            UserDetails user = userService.getUserByEmail(jwtUtil.extractClaim(token, "email"));
-            if(SecurityContextHolder.getContext().getAuthentication() == null && user != null){
-                var auth = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        var token = this.recoveryToken(request);
+
+        if (token != null && jwtUtil.validateToken(token)) {
+            UserDetails userDetails = userService.getUserByEmail(jwtUtil.extractClaim(token, "email"));
+
+            if (SecurityContextHolder.getContext().getAuthentication() == null && userDetails != null) {
+                var auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+
+            UserEntity user = (UserEntity) userDetails;
+            String path = request.getRequestURI();
+
+            boolean isPublicPath = path.startsWith("/api/v1/auth/")
+                    || path.startsWith("/swagger-ui")
+                    || path.startsWith("/v3/api-docs");
+
+            if (!isPublicPath) {
+
+                if (Boolean.TRUE.equals(user.getRequiresPasswordReset())) {
+                    boolean isPasswordResetPath = path.equals("/api/v1/users/password");
+                    if (!isPasswordResetPath) {
+                        String origin = request.getHeader("Origin");
+                        if (origin != null) {
+                            response.setHeader("Access-Control-Allow-Origin", origin);
+                            response.setHeader("Access-Control-Allow-Credentials", "true");
+                        }
+                        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                        response.setContentType("application/json");
+                        response.getWriter().write(
+                                "{\"message\":\"Password reset required before continuing.\",\"data\":null}"
+                        );
+                        return;
+                    }
+                }
+
+                if (Boolean.FALSE.equals(user.getRequiresPasswordReset())
+                        && Boolean.TRUE.equals(user.getRequiresProfileSetup())) {
+                    boolean isProfileSetupPath = path.equals("/api/v1/users/profile");
+                    if (!isProfileSetupPath) {
+                        String origin = request.getHeader("Origin");
+                        if (origin != null) {
+                            response.setHeader("Access-Control-Allow-Origin", origin);
+                            response.setHeader("Access-Control-Allow-Credentials", "true");
+                        }
+                        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                        response.setContentType("application/json");
+                        response.getWriter().write(
+                                "{\"message\":\"Profile setup required before continuing.\",\"data\":null}"
+                        );
+                        return;
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/auth/UserEntity.java
+++ b/src/main/java/com/fluveny/fluveny_backend/infraestructure/entity/auth/UserEntity.java
@@ -37,6 +37,7 @@ public class UserEntity implements UserDetails {
     private Long xp;
     private Long maxXp;
     private Boolean soundEnabled;
+    private Boolean requiresProfileSetup = false;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {


### PR DESCRIPTION
**Enforce first-access flow for content creators**

This PR implements a mandatory first-access flow for content creator accounts created by admins. When a new creator logs in for the first time, they are required to reset their temporary password and set up their profile before accessing the platform.

**Changes**

- Added `requiresProfileSetup` flag to `UserEntity`, propagated through `LoginResultDTO`, `LoginResponseDTO`, `UserResponseDTO`, and `UserMapper`
- `AdminService` now sets both `requiresPasswordReset` and `requiresProfileSetup` to `true` on content creator creation; also fixed the temporary password generator to use only characters allowed by the password validation regex
- `SecurityFilter` now intercepts requests from users with pending first-access steps and returns `403` with proper CORS headers, blocking all endpoints except the required one for each step
- `SecurityConfiguration` explicitly permits `PUT /users/password` and `PUT /users/profile` for authenticated users during the first-access flow
- `AuthController` `/me` endpoint now includes `requiresProfileSetup` in the response
- `UserService` clears `requiresProfileSetup` upon successful profile update
- Fixed password validation regex in `LoginRequestDTO` to accept dot (`.`) as a valid special character